### PR TITLE
Fix a crash in UrlHelper if document isn't defined

### DIFF
--- a/JavaScript/JavaScriptSDK/Util.ts
+++ b/JavaScript/JavaScriptSDK/Util.ts
@@ -453,7 +453,7 @@ module Microsoft.ApplicationInsights {
 
         public static parseUrl(url): HTMLAnchorElement {
             if (!UrlHelper.htmlAnchorElement) {
-                UrlHelper.htmlAnchorElement = UrlHelper.document.createElement('a');
+                UrlHelper.htmlAnchorElement = !!UrlHelper.document.createElement ? UrlHelper.document.createElement('a'): {};
             }
 
             UrlHelper.htmlAnchorElement.href = url;


### PR DESCRIPTION
Calling createElement() on an empty object causes an exception, instead check if document.createElement is defined
